### PR TITLE
fix(frontend/nginx): ensure /static proxies to backend via sidecar and takes precedence

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -54,10 +54,9 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
-        # Static assets served by backend (frames, rendered videos, etc.)
-        # In Consul Connect, Nginx (same alloc) should talk to the local upstream listener
-        # exposed by the sidecar at 127.0.0.1:8000 (not the public listener port).
-        location /static/ {
+        # IMPORTANT: proxy /static BEFORE regex static caching and use ^~ to avoid regex takeover
+        # Backend-served frames/renders via sidecar upstream listener at 127.0.0.1:8000
+        location ^~ /static/ {
             proxy_pass http://127.0.0.1:8000;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
Add location ^~ /static/ before regex static block
Proxy /static to http://127.0.0.1:8000 (sidecar upstream listener)
Prevent regex location ~* \.(png|jpg|...)$ from hijacking images, eliminating 404s for frame URLs